### PR TITLE
fix - mobile menu position

### DIFF
--- a/style.css
+++ b/style.css
@@ -20,6 +20,7 @@ nav {
   display: flex;
   align-items: center;
   padding: 20px 0;
+  flex: 1;
 }
 .logo img {
   width: 100px;


### PR DESCRIPTION
Ajustei o css para corrigir o problema do menu hamurger ficar colado na logo quando acessado pelo celular, testei somente no safari pelo iphone e no chrome pelo console de desenvolvedor e em ambos ficou na posição correta